### PR TITLE
fix: Workflow ID 改用 currentDate 日期 + 随机后缀，消除时区偏差

### DIFF
--- a/skills/risk-classifier/SKILL.md
+++ b/skills/risk-classifier/SKILL.md
@@ -83,7 +83,7 @@ Read `./phase1-output-template.md` for output format and user confirmation flow.
 
 ### State Persistence
 
-After Phase 1 user confirmation, write ECW state to `.claude/ecw/session-data/{workflow-id}/session-state.md`. The `{workflow-id}` is the `Created` timestamp in `YYYYMMDD-HHmm` format — create the directory on first write.
+After Phase 1 user confirmation, write ECW state to `.claude/ecw/session-data/{workflow-id}/session-state.md`. Generate `{workflow-id}` as `{YYYYMMDD}-{xxxx}` where `YYYYMMDD` comes from the `currentDate` system-reminder (reliable local date) and `xxxx` is a 4-digit random hex suffix (e.g., `20260429-a3f1`). Do NOT use Claude's internal time perception for the date or time component — it drifts from local timezone. Create the directory on first write.
 
 **Before writing**, Read `./session-state-format.md` for the exact template, marker conventions, working modes, session data path conventions, and context advisory.
 

--- a/skills/risk-classifier/session-state-format.md
+++ b/skills/risk-classifier/session-state-format.md
@@ -13,8 +13,8 @@ Write this template to `.claude/ecw/session-data/{workflow-id}/session-state.md`
 - **Mode**: {single-domain/cross-domain}
 - **Routing**: {full routing chain}
 - **Current Phase**: phase1-complete
-- **Created**: {YYYY-MM-DD HH:mm}
-- **Workflow ID**: {YYYYMMDD-HHmm}
+- **Created**: {YYYY-MM-DD}
+- **Workflow ID**: {YYYYMMDD-xxxx}
 - **Implementation Strategy**: TBD (determined after ecw:writing-plans based on Task count)
 - **Post-Implementation Tasks**: {fill after Route Task Creation, e.g., "impl-verify(#3) → biz-impact-analysis(#4) → phase3(#5)"}
 - **Auto-Continue**: yes
@@ -32,6 +32,13 @@ Write this template to `.claude/ecw/session-data/{workflow-id}/session-state.md`
 |-------|-------|------|-------|-----------|---------|----------|
 <!-- ECW:LEDGER:END -->
 ```
+
+## Workflow ID Generation
+
+- **Date part**: Read from `currentDate` system-reminder (format `YYYY/MM/DD`) — this is injected by the runtime from the user's local clock and is timezone-correct. Convert to `YYYYMMDD`.
+- **Suffix**: 4 random hex characters (e.g., `a3f1`). Never use wall-clock time (HH:mm) — Claude's internal time perception does not track local timezone reliably.
+- **Example**: `20260429-a3f1`
+- **Created field**: Use the date from `currentDate` only, formatted as `YYYY-MM-DD` (no time component).
 
 ## Marker Conventions
 

--- a/templates/artifact-schemas.md
+++ b/templates/artifact-schemas.md
@@ -41,8 +41,8 @@ All artifact headings, table headers, and field labels MUST be output in the lan
 - **Mode**: {single-domain/cross-domain}
 - **Routing**: {full routing chain}
 - **Current Phase**: phase1-complete
-- **Created**: {YYYY-MM-DD HH:mm}
-- **Workflow ID**: {YYYYMMDD-HHmm}
+- **Created**: {YYYY-MM-DD}
+- **Workflow ID**: {YYYYMMDD-xxxx}
 - **Implementation Strategy**: TBD
 - **Post-Implementation Tasks**: {e.g., "impl-verify(#3) → biz-impact-analysis(#4) → phase3(#5)"}
 - **Auto-Continue**: yes


### PR DESCRIPTION
## Summary

- **根因**：Claude 内部时间感知使用 UTC+0，不跟踪用户本地时区，导致 `Created` 和 `Workflow ID` 中的时间偏差约 4 小时（CST 用户实测）
- **修复**：Workflow ID 日期部分改用 `currentDate` system-reminder 注入的可靠本地日期，时间后缀改为 4 位随机 hex（如 `20260429-a3f1`），彻底消除对 Claude 时间感知的依赖
- **Created 字段**：只保留日期（`YYYY-MM-DD`），去掉不可信的 `HH:mm`

## Changed Files

- `skills/risk-classifier/SKILL.md` — 更新 workflow-id 生成规则说明
- `skills/risk-classifier/session-state-format.md` — 更新模板格式 + 新增 "Workflow ID Generation" 说明节
- `templates/artifact-schemas.md` — 同步 session-state.md schema

## Test plan

- [ ] 触发 risk-classifier 后检查 `session-state.md`：`Created` 只有日期，`Workflow ID` 为 `YYYYMMDD-xxxx` 格式
- [ ] 确认日期与用户本地日期一致（不再偏移 4 小时）
- [ ] 同一天多次触发：每次 Workflow ID 后缀不同，不发生目录覆盖

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)